### PR TITLE
Split loads beta

### DIFF
--- a/samples/api-completedLoad.json
+++ b/samples/api-completedLoad.json
@@ -81,7 +81,7 @@
 	},
 	"tradeItem": [{
 		"quantity": "12",
-		"harmonizeSystemCode": "4712345",
+		"harmonizeSystemCode": "470710000",
 		"description": "OCC 90/10",
 		"grossWeight": {
 			"value": "11333",
@@ -89,8 +89,8 @@
 		}
 	},{
 		"quantity": "15",
-		"harmonizeSystemCode": "4712345",
-		"description": "OCC 90/10",
+		"harmonizeSystemCode": "47079090",
+		"description": "Mixed Material",
 		"grossWeight": {
 			"value": "14167",
 			"unit": "KGM"

--- a/samples/api-completedLoad.json
+++ b/samples/api-completedLoad.json
@@ -79,13 +79,21 @@
 			"unit": "KGM"
 		}
 	},
-	"tradeItem": {
-		"quantity": "25",
+	"tradeItem": [{
+		"quantity": "12",
 		"harmonizeSystemCode": "4712345",
 		"description": "OCC 90/10",
 		"grossWeight": {
-			"value": "25500",
+			"value": "11333",
 			"unit": "KGM"
 		}
-	}
+	},{
+		"quantity": "15",
+		"harmonizeSystemCode": "4712345",
+		"description": "OCC 90/10",
+		"grossWeight": {
+			"value": "14167",
+			"unit": "KGM"
+		}
+	}]
 }

--- a/samples/api-loadPlan.json
+++ b/samples/api-loadPlan.json
@@ -56,10 +56,13 @@
     "shipper": {
         "organizationId": "TQGBACMEL"
     },
-    "tradeItem": {
+    "tradeItem": [{
         "harmonizeSystemCode": "47071000",
         "description": "OCC 90/10"
-    },
+    },{
+        "harmonizeSystemCode": "47079090",
+        "description": "Mixed Material"
+    }],
     "loadingSite": {
         "organizationId": "GBLIVRFAC"
     },


### PR DESCRIPTION
Concept for demonstrating split loads.

use case is when a shipper wants to load multiple materials in a trailer or container and requests this in the [load plan](https://github.com/RecyclingAssociation/traqa/blob/splitLoads-beta/samples/api-loadPlan.json) see that trade item is now an array of objects.

this would trigger the intervention for split loads for shipper to review before accepting the data.

shipper reviews/modifies or accepts the data from site via the agreed process.

[Completed Load plan](https://github.com/RecyclingAssociation/traqa/blob/splitLoads-beta/samples/api-completedLoad.json) shows the multiple lines with weights for each product and bale count.

**NOTE:** the other use case is that the shipper may only enter 1 commodity line, and the site loads multiple commodities, in that case the [Completed Load plan](https://github.com/RecyclingAssociation/traqa/blob/splitLoads-beta/samples/api-completedLoad.json) will come back with multiple product lines, this would need to be handled by the shippers system to handle and accept the multiple line and import the other line into their system.
